### PR TITLE
Prevent user from being stuck in the state of "wait_register_location".

### DIFF
--- a/denguefever_tw/dengue_linebot/views.py
+++ b/denguefever_tw/dengue_linebot/views.py
@@ -383,7 +383,8 @@ def _push_msg(users, text, img):
                 line_bot_api.multicast([user.user_id for user in users], msgs)
                 push_logs = ["Successfully pushed msg to {user}".format(user=user) for user in users]
             except LineBotApiError as e:
-                push_logs = e.error.details
+                _log_line_api_error(e)
+                push_logs = [e.error.message]
             finally:
                 yield push_logs
     else:

--- a/denguefever_tw/static/dengue_linebot/config/FSM.json
+++ b/denguefever_tw/static/dengue_linebot/config/FSM.json
@@ -451,7 +451,8 @@
                 "ask_usage",
                 "ask_prevention",
                 "wait_user_location",
-                "wait_gov_location"
+                "wait_gov_location",
+                "wait_register_location"
             ],
             "dest": "unrecognized_msg",
             "conditions": "is_pass"


### PR DESCRIPTION
- Prevent user from being stuck in the state of "wait_register_location".
- In _push_msg, log and yield the error message when exception occurs.